### PR TITLE
fixed issue with compatibility of Storage.discover() method

### DIFF
--- a/radicale_sql/__init__.py
+++ b/radicale_sql/__init__.py
@@ -10,7 +10,7 @@ import string
 import itertools
 import json
 from hashlib import sha256
-from typing import Optional, Union, Tuple, Iterable, Iterator, Mapping
+from typing import Optional, Union, Tuple, Iterable, Iterator, Mapping, Callable, ContextManager, Set
 import radicale.types
 from radicale.storage import BaseStorage, BaseCollection
 from radicale.log import logger
@@ -595,7 +595,11 @@ class Storage(BaseStorage):
             l += list(self_collection._get_all(connection=connection))
         return l
 
-    def discover(self, path: str, depth: str = "0") -> Iterable["radicale.types.CollectionOrItem"]:
+    def discover(
+            self, path: str, depth: str = "0",
+            child_context_manager: Optional[
+            Callable[[str, Optional[str]], ContextManager[None]]] = None,
+            user_groups: Set[str] = set([])) -> Iterable["radicale.types.CollectionOrItem"]:
         with self._engine.begin() as c:
             return self._discover(path, connection=c, depth=depth)
 


### PR DESCRIPTION
This is to address issue
```
Traceback (most recent call last):
File "/usr/local/lib/python3.12/site-packages/radicale/app/__init__.py", line 115, in call
status_text, headers, answers = self._handle_request(environ)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/site-packages/radicale/app/__init__.py", line 316, in handlerequest
status, headers, answer = function(
^^^^^^^^^
File "/usr/local/lib/python3.12/site-packages/radicale/app/propfind.py", line 394, in do_PROPFIND
items_iter = iter(self._storage.discover(
^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Storage.discover() takes from 2 to 3 positional arguments but 5 were given
```